### PR TITLE
feature/wall-vertical-stack-height-snap

### DIFF
--- a/index.html
+++ b/index.html
@@ -730,7 +730,7 @@
 
     <div id="inventoryPanel" aria-hidden="true">
       <div class="inventoryCard">
-        <button id="inventoryCloseBtn" class="btn inventoryCloseBtn">E Fermer</button>
+        <button id="inventoryCloseBtn" class="btn inventoryCloseBtn">R Fermer</button>
 
         <div class="inventoryHero">
           <div class="label">Build inventory</div>
@@ -769,7 +769,7 @@
           </div>
         </div>
 
-        <div id="inventoryHelp" class="inventoryHelpMini">← → / A D catégories • ↑ ↓ / W S variantes • Enter valider • E fermer</div>
+        <div id="inventoryHelp" class="inventoryHelpMini">← → / A D catégories • ↑ ↓ / W S variantes • Enter valider • R fermer</div>
       </div>
     </div>
 
@@ -799,7 +799,7 @@
         </div>
       </div>
 
-      <div id="hint" class="card hintCard">WASD = déplacement • E = inventaire • inventaire : flèches / WASD = navigation • gameplay : ↑ / ↓ = zoom, ← / → = rotation 45° • Q = cycle modes • molette = zoom • Espace = action contextuelle • M = mission / exploration • C = cycle caméra • R = relancer</div>
+      <div id="hint" class="card hintCard">WASD = déplacement • R = inventaire • inventaire : flèches / WASD = navigation • gameplay : ↑ / ↓ = zoom, ← / → = rotation 45° • Espace / clic = 1 action • hold = répétition après 1 s • E = mode destruction • en destruction : ↑ / ↓ = cible verticale • Q = cycle modes • molette = zoom • M = mission / exploration • C = cycle caméra • Z = reset</div>
     </div>
   </div>
 

--- a/src/assets/customAssets.js
+++ b/src/assets/customAssets.js
@@ -68,6 +68,12 @@ function createNormalizedTemplate(THREE, geometry, material) {
 
   const root = new THREE.Group();
   root.add(mesh);
+  root.userData.wallMetrics = {
+    height: size.y * scale,
+    spanX: size.x * scale,
+    spanZ: size.z * scale,
+    minY: 0,
+  };
   return root;
 }
 
@@ -257,7 +263,20 @@ export function createCustomAssetRegistry({ THREE, storageKey = STORAGE_KEY } = 
     return selectedItemId || null;
   }
 
-  function createWallInstance(variantId, { x = 0, z = 0 } = {}) {
+  function getWallHeight(variantId) {
+    if (!isCustomVariant(variantId)) return 1;
+
+    const assetId = variantId.slice(CUSTOM_VARIANT_PREFIX.length);
+    const recordIndex = records.findIndex((record) => record.id === assetId);
+    if (recordIndex < 0) return 1;
+
+    const record = records[recordIndex];
+    const template = buildTemplate(record, recordIndex);
+    const height = template?.userData?.wallMetrics?.height;
+    return Number.isFinite(height) && height > 0 ? height : 1;
+  }
+
+  function createWallInstance(variantId, { x = 0, y = 0, z = 0 } = {}) {
     if (!isCustomVariant(variantId)) return null;
 
     const assetId = variantId.slice(CUSTOM_VARIANT_PREFIX.length);
@@ -267,7 +286,7 @@ export function createCustomAssetRegistry({ THREE, storageKey = STORAGE_KEY } = 
     const record = records[recordIndex];
     const template = buildTemplate(record, recordIndex);
     const instance = cloneTemplate(template);
-    instance.position.set(x, 0, z);
+    instance.position.set(x, y, z);
     return instance;
   }
 
@@ -282,6 +301,7 @@ export function createCustomAssetRegistry({ THREE, storageKey = STORAGE_KEY } = 
     isCustomVariant,
     getDefaultWallSelection,
     resolveWallSelection,
+    getWallHeight,
     createWallInstance,
   };
 }

--- a/src/entities/player.js
+++ b/src/entities/player.js
@@ -5,6 +5,15 @@ import { clamp, normalize2D } from '../utils/math.js';
 import { INNER_LIMIT as DEFAULT_INNER_LIMIT } from '../config.js';
 import { getPlayerModeDef } from './playerModes.js';
 
+const WALL_GRID_SNAP_EPSILON = 0.001;
+const WALL_GRID_SNAP_LERP_SPEED = 12;
+
+function smoothToward(current, target, delta, speed) {
+  if (!Number.isFinite(current) || !Number.isFinite(target)) return target;
+  const factor = 1 - Math.exp(-Math.max(0, speed) * Math.max(0, delta));
+  return current + ((target - current) * factor);
+}
+
 function disposeObject3D(object) {
   if (!object) return;
 
@@ -58,6 +67,17 @@ export function createPlayerSystem({
   let group = null;
   let core = null;
   let halo = null;
+  const buildIndicator = {
+    active: false,
+    level: 0,
+    destroyMode: false,
+    previewBaseY: 0,
+    previewCenterY: 0.5,
+    previewTopY: 1.0,
+    previewCellX: 0,
+    previewCellZ: 0,
+    stepHeight: 1,
+  };
 
   function getLegacyMovementIntent() {
     const left = !!(keys && (keys.arrowleft || keys.q || keys.a));
@@ -85,6 +105,55 @@ export function createPlayerSystem({
     return def.createCore(THREE);
   }
 
+  function getIndicatorLocalY() {
+    if (!group) return 0;
+    const previewTopY = Number.isFinite(buildIndicator.previewTopY)
+      ? buildIndicator.previewTopY
+      : ((Number.isFinite(buildIndicator.previewCenterY) ? buildIndicator.previewCenterY : 0.5)
+        + ((Number.isFinite(buildIndicator.stepHeight) ? buildIndicator.stepHeight : 1) * 0.5));
+    return previewTopY - group.position.y;
+  }
+
+  function getIndicatorLocalXZ() {
+    if (!group) return { x: 0, z: 0 };
+    return { x: 0, z: 0 };
+  }
+
+  function applyHaloBaseState() {
+    if (!halo) return;
+    const material = halo.material;
+    if (!material || !material.color) return;
+
+    const baseX = Number.isFinite(halo.userData.baseX) ? halo.userData.baseX : halo.position.x;
+    const baseY = Number.isFinite(halo.userData.baseY) ? halo.userData.baseY : halo.position.y;
+    const baseZ = Number.isFinite(halo.userData.baseZ) ? halo.userData.baseZ : halo.position.z;
+    const baseOpacity = Number.isFinite(halo.userData.baseOpacity) ? halo.userData.baseOpacity : 0.5;
+    const baseColor = Number.isFinite(halo.userData.baseColor) ? halo.userData.baseColor : material.color.getHex();
+
+    const showBuildIndicator = !!buildIndicator.active && player?.mode === 'wall';
+    const targetColor = showBuildIndicator
+      ? (buildIndicator.destroyMode ? 0xff5f5f : 0x8df8ff)
+      : baseColor;
+
+    material.color.setHex(targetColor);
+    if (showBuildIndicator) {
+      const localPos = getIndicatorLocalXZ();
+      halo.position.x = localPos.x;
+      halo.position.y = getIndicatorLocalY();
+      halo.position.z = localPos.z;
+    } else {
+      halo.position.x = baseX;
+      halo.position.y = baseY;
+      halo.position.z = baseZ;
+    }
+    halo.userData.runtimeOpacityBase = showBuildIndicator
+      ? (buildIndicator.destroyMode ? 0.72 : 0.62)
+      : baseOpacity;
+    halo.userData.runtimeScaleBase = showBuildIndicator
+      ? (buildIndicator.destroyMode ? 1.08 : 1.03)
+      : 1;
+  }
+
   function rebuildVisualForMode(mode) {
     const def = getPlayerModeDef(mode);
     if (!group) return;
@@ -105,7 +174,17 @@ export function createPlayerSystem({
     halo = def.createHalo(THREE);
 
     if (core) group.add(core);
-    if (halo) group.add(halo);
+    if (halo) {
+      halo.userData.baseX = halo.position.x;
+      halo.userData.baseY = halo.position.y;
+      halo.userData.baseZ = halo.position.z;
+      halo.userData.baseOpacity = halo.material?.opacity ?? 0.5;
+      halo.userData.baseColor = halo.material?.color?.getHex?.() ?? 0xffffff;
+      halo.userData.runtimeOpacityBase = halo.userData.baseOpacity;
+      halo.userData.runtimeScaleBase = 1;
+      group.add(halo);
+      applyHaloBaseState();
+    }
   }
 
   function setMode(mode) {
@@ -189,6 +268,23 @@ export function createPlayerSystem({
       player.z = nextZ;
     }
 
+    const isWallMode = player.mode === 'wall';
+    const hasMovementInput = moveX !== 0 || moveZ !== 0;
+    if (isWallMode && !hasMovementInput) {
+      const snapTargetX = clamp(Math.round(player.x), -INNER_LIMIT, INNER_LIMIT);
+      const snapTargetZ = clamp(Math.round(player.z), -INNER_LIMIT, INNER_LIMIT);
+
+      const snappedX = smoothToward(player.x, snapTargetX, delta, WALL_GRID_SNAP_LERP_SPEED);
+      if (!collidesAtPlayer(snappedX, player.z, player.radius)) {
+        player.x = Math.abs(snappedX - snapTargetX) <= WALL_GRID_SNAP_EPSILON ? snapTargetX : snappedX;
+      }
+
+      const snappedZ = smoothToward(player.z, snapTargetZ, delta, WALL_GRID_SNAP_LERP_SPEED);
+      if (!collidesAtPlayer(player.x, snappedZ, player.radius)) {
+        player.z = Math.abs(snappedZ - snapTargetZ) <= WALL_GRID_SNAP_EPSILON ? snapTargetZ : snappedZ;
+      }
+    }
+
     const t = getTimeElapsed ? getTimeElapsed() : 0;
     if (group) {
       group.position.x = player.x;
@@ -203,8 +299,11 @@ export function createPlayerSystem({
     }
 
     if (halo?.material) {
-      halo.material.opacity = 0.38 + Math.sin(t * 4.2) * 0.05;
-      halo.scale.setScalar(1 + Math.sin(t * 5.2) * 0.03);
+      applyHaloBaseState();
+      const opacityBase = Number.isFinite(halo.userData.runtimeOpacityBase) ? halo.userData.runtimeOpacityBase : 0.38;
+      const scaleBase = Number.isFinite(halo.userData.runtimeScaleBase) ? halo.userData.runtimeScaleBase : 1;
+      halo.material.opacity = opacityBase + Math.sin(t * 4.2) * 0.05;
+      halo.scale.setScalar(scaleBase + Math.sin(t * 5.2) * 0.03);
     }
   }
 
@@ -216,6 +315,19 @@ export function createPlayerSystem({
     return player ? player.mode : 'wall';
   }
 
+  function setBuildIndicator(state = {}) {
+    buildIndicator.active = !!state.active;
+    buildIndicator.level = Number.isFinite(state.level) ? state.level : 0;
+    buildIndicator.destroyMode = !!state.destroyMode;
+    buildIndicator.previewBaseY = Number.isFinite(state.previewBaseY) ? state.previewBaseY : 0;
+    buildIndicator.previewCenterY = Number.isFinite(state.previewCenterY) ? state.previewCenterY : (buildIndicator.previewBaseY + 0.5);
+    buildIndicator.previewTopY = Number.isFinite(state.previewTopY) ? state.previewTopY : (buildIndicator.previewCenterY + ((Number.isFinite(state.stepHeight) ? state.stepHeight : 1) * 0.5));
+    buildIndicator.previewCellX = Number.isFinite(state.previewCellX) ? state.previewCellX : 0;
+    buildIndicator.previewCellZ = Number.isFinite(state.previewCellZ) ? state.previewCellZ : 0;
+    buildIndicator.stepHeight = Number.isFinite(state.stepHeight) ? state.stepHeight : 1;
+    applyHaloBaseState();
+  }
+
   return {
     create,
     update,
@@ -223,5 +335,6 @@ export function createPlayerSystem({
     getPlayer,
     getMode,
     setMode,
+    setBuildIndicator,
   };
 }

--- a/src/entities/playerModes.js
+++ b/src/entities/playerModes.js
@@ -220,7 +220,7 @@ function createFallbackProjectileMesh(THREE) {
 
 const AQUA_STYLE = Object.freeze({
   cellHalf: 0.5,
-  surfaceY: 0.14,
+  surfaceY: 0.0,
   baseLift: 0.036,
   waveAmpA: 0.013,
   waveAmpB: 0.009,
@@ -848,9 +848,6 @@ export function createPlayerModesSystem({
 
     switch (currentMode) {
       case 'wall':
-        if (wallsSystem && typeof wallsSystem.toggleWallAtPlayer === 'function') {
-          wallsSystem.toggleWallAtPlayer();
-        }
         break;
       case 'projectile':
         spawnProjectile();

--- a/src/game/reset.js
+++ b/src/game/reset.js
@@ -66,7 +66,12 @@ export function createResetSystem(opts) {
     runtime.spawnCooldown = 0.4;
 
     const wallsSystem = getWallsSystem ? getWallsSystem() : null;
-    if (wallsSystem) wallsSystem.clearLastActionCell();
+    if (wallsSystem) {
+      if (typeof wallsSystem.isDestroyModeActive === 'function' && wallsSystem.isDestroyModeActive()) {
+        if (typeof wallsSystem.toggleDestroyMode === 'function') wallsSystem.toggleDestroyMode();
+      }
+      if (typeof wallsSystem.clearLastActionCell === 'function') wallsSystem.clearLastActionCell();
+    }
 
     const playerSystem = getPlayerSystem ? getPlayerSystem() : null;
     const player = getPlayer ? getPlayer() : null;

--- a/src/input/actions.js
+++ b/src/input/actions.js
@@ -2,7 +2,7 @@
 // Mapping gameplay #38 :
 // - WASD = déplacement
 // - Q = cycle des modes joueur
-// - E = inventaire
+// - R = inventaire
 // - flèches = caméra (zoom / rotation)
 // - clic gauche souris = action principale (build / fire)
 // Les raccourcis historiques C / J / L / X restent tolérés en alias léger.
@@ -35,11 +35,14 @@ export function createActionController(input) {
     isPrimaryActionHeld() {
       return input.isDown('space') || input.isDown('mouseleft');
     },
+    consumePrimaryActionPress() {
+      return input.consumePress('space') || input.consumePress('mouseleft');
+    },
     consumePrimaryActionRelease() {
       return input.consumeRelease('space') || input.consumeRelease('mouseleft');
     },
     consumeRestart() {
-      return input.consumePress('r');
+      return input.consumePress('z');
     },
     consumeCycleCamera() {
       return input.consumePress('c');
@@ -75,6 +78,10 @@ export function createActionController(input) {
       return input.consumePress('enter');
     },
     consumeInventoryToggle() {
+      return input.consumePress('r');
+    },
+
+    consumeToggleWallDestroyMode() {
       return input.consumePress('e');
     },
     consumeNextPlayerMode() {

--- a/src/input/keyboard.js
+++ b/src/input/keyboard.js
@@ -2,13 +2,13 @@
 // Mapping recentré sur la tâche #38 :
 // - WASD = déplacement
 // - Q = cycle des modes joueur
-// - E = inventaire (placeholder UI)
-// - flèches = caméra (zoom / rotation)
+// - R = inventaire (placeholder UI)
+// - flèches = caméra (zoom / rotation), sauf en destruction mur pour la sélection verticale
 // - clic gauche souris = action principale (build / fire)
 const HANDLED_KEYS = new Set([
   'arrowup', 'arrowdown', 'arrowleft', 'arrowright',
   'space', 'enter', 'w', 'a', 's', 'd', 'q', 'e',
-  'shift', 'r', 'v', 'c', 'm', 'j', 'l', 'x',
+  'shift', 'r', 'v', 'c', 'm', 'j', 'l', 'x', 'f', 'g', 'z',
 ]);
 
 function normalizeKey(event) {

--- a/src/main.js
+++ b/src/main.js
@@ -394,6 +394,24 @@ const THREE = window.THREE;
   }
 
   function refreshHud() {
+    const stackState = wallsSystem && typeof wallsSystem.getStackState === 'function'
+      ? wallsSystem.getStackState()
+      : { level: -1, displayLevel: 0, stepHeight: 0, destroyMode: false };
+
+    if (playerSystem && typeof playerSystem.setBuildIndicator === 'function') {
+      playerSystem.setBuildIndicator({
+        active: !inventoryOpen && !!modeSystem && typeof modeSystem.getCurrentMode === 'function' && modeSystem.getCurrentMode() === 'wall',
+        level: stackState.level,
+        destroyMode: !!stackState.destroyMode,
+        previewBaseY: stackState.previewBaseY,
+        previewCenterY: stackState.previewCenterY,
+        previewTopY: stackState.previewTopY,
+        previewCellX: stackState.previewCellX,
+        previewCellZ: stackState.previewCellZ,
+        stepHeight: stackState.stepHeight,
+      });
+    }
+
     hud.refresh({
       score,
       enemiesCount: enemies.length,
@@ -406,6 +424,12 @@ const THREE = window.THREE;
       playerModeLabel: modeSystem ? modeSystem.getCurrentModeLabel() : 'WALL',
       inventoryOpen,
       inventorySelectionLabel: inventoryMenu.getSelectionSummary(),
+      wallStackLevel: stackState.level,
+      wallStackDisplayLevel: stackState.displayLevel,
+      wallStackStep: stackState.stepHeight,
+      wallDestroyMode: !!stackState.destroyMode,
+      wallPreviewBaseY: stackState.previewBaseY,
+      wallPreviewCenterY: stackState.previewCenterY,
     });
   }
 
@@ -501,12 +525,45 @@ const THREE = window.THREE;
       toggleWorldMode();
     }
 
-    if (actions.consumeZoomIn() && cameraController) {
-      cameraController.zoomBy(1);
+    if (
+      actions.consumeToggleWallDestroyMode()
+      && !inventoryOpen
+      && modeSystem
+      && typeof modeSystem.getCurrentMode === 'function'
+      && modeSystem.getCurrentMode() === 'wall'
+      && wallsSystem
+      && typeof wallsSystem.toggleDestroyMode === 'function'
+    ) {
+      wallsSystem.toggleDestroyMode();
     }
 
-    if (actions.consumeZoomOut() && cameraController) {
-      cameraController.zoomBy(-1);
+    const wallDestroyModeActive = wallsSystem && typeof wallsSystem.isDestroyModeActive === 'function'
+      ? wallsSystem.isDestroyModeActive()
+      : false;
+
+    const wallModeActive = !inventoryOpen
+      && modeSystem
+      && typeof modeSystem.getCurrentMode === 'function'
+      && modeSystem.getCurrentMode() === 'wall';
+
+    if (actions.consumeZoomIn()) {
+      if (wallModeActive && wallDestroyModeActive && wallsSystem && typeof wallsSystem.nudgeDestroySelection === 'function') {
+        wallsSystem.nudgeDestroySelection(1);
+      } else if (wallModeActive && wallsSystem && typeof wallsSystem.nudgeBuildSelection === 'function') {
+        wallsSystem.nudgeBuildSelection(1);
+      } else if (cameraController) {
+        cameraController.zoomBy(1);
+      }
+    }
+
+    if (actions.consumeZoomOut()) {
+      if (wallModeActive && wallDestroyModeActive && wallsSystem && typeof wallsSystem.nudgeDestroySelection === 'function') {
+        wallsSystem.nudgeDestroySelection(-1);
+      } else if (wallModeActive && wallsSystem && typeof wallsSystem.nudgeBuildSelection === 'function') {
+        wallsSystem.nudgeBuildSelection(-1);
+      } else if (cameraController) {
+        cameraController.zoomBy(-1);
+      }
     }
 
     if (actions.consumeRotateLeft() && cameraController) {
@@ -529,8 +586,48 @@ const THREE = window.THREE;
     }
   }
 
-  function handleContextualActions() {
+  function handleContextualActions(delta) {
     if (!modeSystem || inventoryOpen) return;
+
+    const currentMode = typeof modeSystem.getCurrentMode === 'function' ? modeSystem.getCurrentMode() : null;
+
+    if (currentMode === 'wall' && wallsSystem) {
+      const primaryPressed = actions.consumePrimaryActionPress();
+      const primaryHeld = actions.isPrimaryActionHeld();
+      const primaryReleased = actions.consumePrimaryActionRelease();
+
+      if (primaryPressed && typeof wallsSystem.beginPrimaryActionHold === 'function') {
+        wallsSystem.beginPrimaryActionHold();
+      }
+
+      if (typeof wallsSystem.updatePrimaryActionHold === 'function') {
+        const movementIntent = typeof actions.getMovementIntent === 'function'
+          ? actions.getMovementIntent()
+          : { x: 0, z: 0 };
+        const directionalHeld = (
+          !!movementIntent?.x
+          || !!movementIntent?.z
+          || input.isDown('arrowleft')
+          || input.isDown('arrowright')
+          || input.isDown('arrowup')
+          || input.isDown('arrowdown')
+        );
+        wallsSystem.updatePrimaryActionHold(delta, {
+          primaryHeld,
+          bypassInitialDelay: directionalHeld,
+        });
+      }
+
+      if (primaryReleased) {
+        if (typeof wallsSystem.endPrimaryActionHold === 'function') {
+          wallsSystem.endPrimaryActionHold({ allowTap: true });
+        } else if (typeof wallsSystem.clearLastActionCell === 'function') {
+          wallsSystem.clearLastActionCell();
+        }
+        modeSystem.handlePrimaryActionReleased();
+      }
+      return;
+    }
 
     if (actions.isPrimaryActionHeld()) {
       modeSystem.handlePrimaryActionHeld();
@@ -549,7 +646,8 @@ const THREE = window.THREE;
       timeElapsed += delta;
       actionCooldown = Math.max(0, actionCooldown - delta);
 
-      handleContextualActions();
+
+      handleContextualActions(delta);
 
       if (playerSystem) playerSystem.update(delta);
       if (modeSystem) modeSystem.update(delta);
@@ -664,6 +762,7 @@ const THREE = window.THREE;
       resolveSelectedWallVariant: (variantId) => customAssetRegistry.resolveWallSelection(variantId),
       isCustomWallVariant: (variantId) => customAssetRegistry.isCustomVariant(variantId),
       createCustomWallMesh: (variantId, cell) => customAssetRegistry.createWallInstance(variantId, cell),
+      getCustomWallHeight: (variantId) => customAssetRegistry.getWallHeight(variantId),
       createWallMesh,
     });
 
@@ -701,7 +800,7 @@ const THREE = window.THREE;
     toggleProjectionBtn.style.display = 'none';
     if (hintText) {
       hintText.textContent =
-        'WASD = déplacement • E = inventaire • inventaire : flèches / WASD = navigation • gameplay : ↑ / ↓ = zoom, ← / → = rotation 45° • Q = cycle murs / projectile / aqua / véhicule • molette = zoom • Espace = action contextuelle • M = mission / exploration • C = cycle caméra • R = relancer';
+        'WASD = déplacement • R = inventaire • inventaire : flèches / WASD = navigation • gameplay : ↑ / ↓ = zoom, ← / → = rotation 45° • Espace / clic = 1 action • hold = répétition après 1 s • E = mode destruction • en destruction : ↑ / ↓ = cible verticale • Q = cycle murs / projectile / aqua / véhicule • molette = zoom • M = mission / exploration • C = cycle caméra • Z = reset';
     }
 
     toggleSandboxBtn.addEventListener('click', () => {

--- a/src/ui/hud.js
+++ b/src/ui/hud.js
@@ -2,9 +2,22 @@
 // Ajoute un rappel léger du mode player et de l'état d'inventaire.
 
 export function createHud(els, config) {
+  function formatStackInfo(model) {
+    if (!model || model.playerModeLabel !== 'WALL') return '';
+    const level = Number.isFinite(model.wallStackDisplayLevel)
+      ? model.wallStackDisplayLevel
+      : (Number.isFinite(model.wallStackLevel) ? model.wallStackLevel : 0);
+    const step = Number.isFinite(model.wallStackStep) ? model.wallStackStep : 0;
+    if (model.wallDestroyMode) {
+      return ` • DESTROY • Y ${level} • hold Space • E • ↑/↓ cible`;
+    }
+    return ` • BUILD • Y ${level} • pas ${step.toFixed(2)} • hold Space • ↑/↓ cible • E destroy`;
+  }
+
   function syncViewUi(model) {
     const modePrefix = model.worldMode === 'exploration' ? 'Exploration' : 'Mission';
     const modeSuffix = model.playerModeLabel ? ` • Mode ${model.playerModeLabel}` : '';
+    const stackSuffix = formatStackInfo(model);
 
     if (model.followMode === 'top') {
       els.viewValue.textContent = 'TOP';
@@ -30,13 +43,13 @@ export function createHud(els, config) {
 
     if (model.inventoryOpen) {
       const selection = model.inventorySelectionLabel ? ` • ${model.inventorySelectionLabel}` : '';
-      els.statusText.textContent = `Inventaire ouvert • flèches / WASD = naviguer • E = fermer${selection}${modeSuffix}`;
+      els.statusText.textContent = `Inventaire ouvert • flèches / WASD = naviguer • R = fermer${selection}${modeSuffix}`;
     } else if (model.followMode === 'top') {
-      els.statusText.textContent = `${modePrefix} • Top = lecture claire et déplacement libre${modeSuffix}`;
+      els.statusText.textContent = `${modePrefix} • Top = lecture claire et déplacement libre${modeSuffix}${stackSuffix}`;
     } else if (model.cameraProjectionMode === 'iso') {
-      els.statusText.textContent = `${modePrefix} • Caméra isométrique = lecture douce, style maquette${modeSuffix}`;
+      els.statusText.textContent = `${modePrefix} • Caméra isométrique = lecture douce, style maquette${modeSuffix}${stackSuffix}`;
     } else {
-      els.statusText.textContent = `${modePrefix} • Caméra perspective = suivi plus immersif${modeSuffix}`;
+      els.statusText.textContent = `${modePrefix} • Caméra perspective = suivi plus immersif${modeSuffix}${stackSuffix}`;
     }
 
     els.toggleSandboxBtn.classList.toggle('is-active', model.worldMode === 'exploration');

--- a/src/ui/inventoryMenu.js
+++ b/src/ui/inventoryMenu.js
@@ -354,7 +354,7 @@ export function createInventoryMenu(els, callbacks = {}) {
       els.selectionPillEl.textContent = item ? item.label : category.modeLabel;
     }
     if (els.helpEl) {
-      els.helpEl.textContent = '← → / A D = catégories • ↑ ↓ / W S = variantes • Enter = valider • E = fermer';
+      els.helpEl.textContent = '← → / A D = catégories • ↑ ↓ / W S = variantes • Enter = valider • R = fermer';
     }
 
     renderCategoryRail();

--- a/src/world/walls.js
+++ b/src/world/walls.js
@@ -775,9 +775,27 @@ export function createWallMeshFactory({ THREE, shared }) {
     const mesh = new THREE.Mesh(shared.wallGeo, isBorder ? shared.borderWallMat : shared.userWallMat);
     mesh.castShadow = true;
     mesh.receiveShadow = true;
-    mesh.position.set(x, 1.1, z);
+    mesh.position.set(x, 0.2, z);
     return mesh;
   };
+}
+
+const WALL_ACTION_REPEAT_INITIAL_DELAY = 1.0;
+const WALL_ACTION_REPEAT_DELAY = 0.12;
+const WALL_HEIGHT_FALLBACK = 0.4;
+const WALL_BASE_PRECISION = 1000;
+const WALL_BASE_EPSILON = 1 / WALL_BASE_PRECISION;
+
+function normalizeWallBaseY(value) {
+  return Math.round((Number(value) || 0) * WALL_BASE_PRECISION) / WALL_BASE_PRECISION;
+}
+
+function makeWallActionKey(x, z, baseY) {
+  return `${x}|${z}|${normalizeWallBaseY(baseY).toFixed(3)}`;
+}
+
+function areSameWallBase(a, b) {
+  return Math.abs(normalizeWallBaseY(a) - normalizeWallBaseY(b)) <= WALL_BASE_EPSILON;
 }
 
 export function createWallsSystem({
@@ -795,19 +813,37 @@ export function createWallsSystem({
   resolveSelectedWallVariant,
   isCustomWallVariant,
   createCustomWallMesh,
+  getCustomWallHeight,
   createWallMesh,
 }) {
   let lastWallActionCellKey = '';
+  let destroyMode = false;
+  let actionRepeatTimer = 0;
+  let actionRepeatStarted = false;
+  let primaryActionPrimed = false;
+  let primaryActionPerformed = false;
+  let destroySelectionOffsetFromTop = 0;
+  let destroySelectionCellKey = '';
+  let buildSelectionOffsetFromTop = 0;
   const renderedEntries = [];
   const materialCache = new Map();
+  const variantHeightCache = new Map();
+
+  function getSelectedVariantId() {
+    const selectedVariant = typeof getSelectedWallVariant === 'function' ? getSelectedWallVariant() : 'brick-dense';
+    return selectedVariant || 'brick-dense';
+  }
+
+  function resolveVariantId(variantId) {
+    if (typeof resolveSelectedWallVariant === 'function') {
+      const resolvedVariant = resolveSelectedWallVariant(variantId);
+      return resolvedVariant || variantId || 'brick-dense';
+    }
+    return variantId || 'brick-dense';
+  }
 
   function getCurrentVariant() {
-    const selectedVariant = typeof getSelectedWallVariant === 'function' ? getSelectedWallVariant() : 'brick-dense';
-    if (typeof resolveSelectedWallVariant === 'function') {
-      const resolvedVariant = resolveSelectedWallVariant(selectedVariant);
-      return resolvedVariant || 'brick-dense';
-    }
-    return selectedVariant || 'brick-dense';
+    return resolveVariantId(getSelectedVariantId());
   }
 
   function getMaterialForVariant(variantId) {
@@ -819,23 +855,146 @@ export function createWallsSystem({
     return materialCache.get(variantId);
   }
 
+  function disposeRenderedEntry(entry) {
+    scene.remove(entry.mesh);
+    if (entry.disposeGeometry && entry.mesh.geometry) entry.mesh.geometry.dispose();
+    if (entry.extraGeometries) entry.extraGeometries.forEach((geo) => geo.dispose());
+    if (entry.disposeMaterial && entry.mesh.material) {
+      if (Array.isArray(entry.mesh.material)) entry.mesh.material.forEach((mat) => mat.dispose());
+      else entry.mesh.material.dispose();
+    }
+    if (entry.extraMaterials) entry.extraMaterials.forEach((mat) => mat.dispose());
+  }
+
   function clearRenderedEntries() {
     while (renderedEntries.length) {
-      const entry = renderedEntries.pop();
-      scene.remove(entry.mesh);
-      if (entry.disposeGeometry && entry.mesh.geometry) entry.mesh.geometry.dispose();
-      if (entry.extraGeometries) entry.extraGeometries.forEach((geo) => geo.dispose());
-      if (entry.disposeMaterial && entry.mesh.material) {
-        if (Array.isArray(entry.mesh.material)) entry.mesh.material.forEach((mat) => mat.dispose());
-        else entry.mesh.material.dispose();
-      }
-      if (entry.extraMaterials) entry.extraMaterials.forEach((mat) => mat.dispose());
+      disposeRenderedEntry(renderedEntries.pop());
     }
   }
 
-  function assignMeshesToCells(cells, mesh) {
+
+  function normalizeBuiltMeshBaseY(built) {
+    const object = built?.mesh;
+    if (!object) return 0;
+
+    object.updateMatrixWorld(true);
+    const box = new THREE.Box3().setFromObject(object);
+    if (box.isEmpty()) return 0;
+
+    const offsetY = normalizeWallBaseY(box.min.y);
+    if (Math.abs(offsetY) > WALL_BASE_EPSILON) {
+      object.position.y -= offsetY;
+      object.updateMatrixWorld(true);
+    }
+
+    return offsetY;
+  }
+
+  function getMeasuredHeightFromBuiltMeshes(builtMeshes, measureScene) {
+    let minY = Number.POSITIVE_INFINITY;
+    let maxY = Number.NEGATIVE_INFINITY;
+
+    measureScene.updateMatrixWorld(true);
+    for (const built of builtMeshes) {
+      normalizeBuiltMeshBaseY(built);
+      built.mesh.updateMatrixWorld(true);
+      const box = new THREE.Box3().setFromObject(built.mesh);
+      if (box.isEmpty()) continue;
+      minY = Math.min(minY, box.min.y);
+      maxY = Math.max(maxY, box.max.y);
+    }
+
+    for (const built of builtMeshes) {
+      if (built.mesh.parent) built.mesh.parent.remove(built.mesh);
+      if (built.disposeGeometry && built.mesh.geometry) built.mesh.geometry.dispose();
+      if (built.extraGeometries) built.extraGeometries.forEach((geo) => geo.dispose());
+      if (built.disposeMaterial && built.mesh.material) {
+        if (Array.isArray(built.mesh.material)) built.mesh.material.forEach((mat) => mat.dispose());
+        else built.mesh.material.dispose();
+      }
+      if (built.extraMaterials) built.extraMaterials.forEach((mat) => mat.dispose());
+    }
+
+    if (!Number.isFinite(minY) || !Number.isFinite(maxY) || maxY <= minY) {
+      return WALL_HEIGHT_FALLBACK;
+    }
+
+    return normalizeWallBaseY(maxY - minY);
+  }
+
+  function getWallHeightForVariant(variantId) {
+    if (typeof isCustomWallVariant === 'function' && isCustomWallVariant(variantId)) {
+      const customHeight = typeof getCustomWallHeight === 'function' ? getCustomWallHeight(variantId) : WALL_HEIGHT_FALLBACK;
+      return Number.isFinite(customHeight) && customHeight > 0 ? normalizeWallBaseY(customHeight) : WALL_HEIGHT_FALLBACK;
+    }
+
+    if (variantHeightCache.has(variantId)) return variantHeightCache.get(variantId);
+
+    const style = getVariantStyle(variantId);
+    if (!style) {
+      variantHeightCache.set(variantId, WALL_HEIGHT_FALLBACK);
+      return WALL_HEIGHT_FALLBACK;
+    }
+
+    const material = getMaterialForVariant(variantId);
+    const measureScene = new THREE.Scene();
+    const builtMeshes = buildVariantMesh({
+      THREE,
+      scene: measureScene,
+      cells: [{ x: 0, z: 0 }],
+      style,
+      material,
+    });
+    const measuredHeight = getMeasuredHeightFromBuiltMeshes(builtMeshes, measureScene);
+    variantHeightCache.set(variantId, measuredHeight);
+    return measuredHeight;
+  }
+
+  function getWallHeightValue(wall) {
+    const storedHeight = Number(wall?.height);
+    if (Number.isFinite(storedHeight) && storedHeight > 0) return storedHeight;
+    return getWallHeightForVariant(wall?.variant || 'brick-dense');
+  }
+
+  function getCellWalls(cellX, cellZ) {
+    return userWalls
+      .filter((wall) => wall.x === cellX && wall.z === cellZ)
+      .sort((a, b) => normalizeWallBaseY(a.baseY || 0) - normalizeWallBaseY(b.baseY || 0));
+  }
+
+  function getCellTopY(cellX, cellZ) {
+    let topY = 0;
+    for (const wall of userWalls) {
+      if (wall.x !== cellX || wall.z !== cellZ) continue;
+      const wallTopY = normalizeWallBaseY((wall.baseY || 0) + getWallHeightValue(wall));
+      if (wallTopY > topY) topY = wallTopY;
+    }
+    return normalizeWallBaseY(topY);
+  }
+
+  function updateUserWallSetForCell(cellX, cellZ) {
+    const key = keyForCell(cellX, cellZ);
+    const hasAnyWall = userWalls.some((wall) => wall.x === cellX && wall.z === cellZ);
+    if (hasAnyWall) userWallSet.add(key);
+    else userWallSet.delete(key);
+  }
+
+  function findWallAtBaseY(cellX, cellZ, baseY) {
+    return userWalls.find((wall) => (
+      wall.x === cellX
+      && wall.z === cellZ
+      && areSameWallBase(wall.baseY || 0, baseY)
+    )) || null;
+  }
+
+  function assignMeshesToWalls(cells, variantId, baseY, mesh) {
     for (const cell of cells) {
-      const wall = userWalls.find((entry) => entry.x === cell.x && entry.z === cell.z);
+      const wall = userWalls.find((entry) => (
+        entry.x === cell.x
+        && entry.z === cell.z
+        && (entry.variant || 'brick-dense') === variantId
+        && areSameWallBase(entry.baseY || 0, baseY)
+      ));
       if (wall) wall.mesh = mesh;
     }
   }
@@ -844,32 +1003,40 @@ export function createWallsSystem({
     clearRenderedEntries();
     for (const wall of userWalls) wall.mesh = null;
 
-    const byVariant = new Map();
+    const byVariantAndLayer = new Map();
     for (const wall of userWalls) {
       const variant = wall.variant || 'brick-dense';
-      if (!byVariant.has(variant)) byVariant.set(variant, []);
-      byVariant.get(variant).push(wall);
+      const baseY = normalizeWallBaseY(wall.baseY || 0);
+      const groupKey = `${variant}@@${baseY.toFixed(3)}`;
+      if (!byVariantAndLayer.has(groupKey)) {
+        byVariantAndLayer.set(groupKey, { variantId: variant, baseY, walls: [] });
+      }
+      byVariantAndLayer.get(groupKey).walls.push(wall);
     }
 
-    for (const [variantId, cells] of byVariant) {
+    for (const { variantId, baseY, walls } of byVariantAndLayer.values()) {
       const style = getVariantStyle(variantId);
       if (!style) {
-        const isCustomVariant = typeof isCustomWallVariant === 'function' && isCustomWallVariant(variantId);
-        for (const cell of cells) {
-          const mesh = isCustomVariant && typeof createCustomWallMesh === 'function'
-            ? createCustomWallMesh(variantId, { x: cell.x, z: cell.z })
-            : createWallMesh(cell.x, cell.z, false);
+        const customVariant = typeof isCustomWallVariant === 'function' && isCustomWallVariant(variantId);
+        for (const wall of walls) {
+          const mesh = customVariant && typeof createCustomWallMesh === 'function'
+            ? createCustomWallMesh(variantId, { x: wall.x, y: baseY, z: wall.z })
+            : createWallMesh(wall.x, wall.z, false);
           if (!mesh) continue;
+          if (!customVariant) mesh.position.y = baseY + 0.2;
           scene.add(mesh);
           renderedEntries.push({ mesh, disposeGeometry: false, disposeMaterial: false });
-          cell.mesh = mesh;
+          wall.mesh = mesh;
         }
         continue;
       }
 
       const material = getMaterialForVariant(variantId);
-      const builtMeshes = buildVariantMesh({ THREE, scene, cells, style, material });
+      const layerCells = walls.map(({ x, z }) => ({ x, z }));
+      const builtMeshes = buildVariantMesh({ THREE, scene, cells: layerCells, style, material });
       for (const built of builtMeshes) {
+        normalizeBuiltMeshBaseY(built);
+        built.mesh.position.y += baseY;
         renderedEntries.push({
           mesh: built.mesh,
           disposeGeometry: built.disposeGeometry,
@@ -877,60 +1044,414 @@ export function createWallsSystem({
           extraMaterials: built.extraMaterials,
           extraGeometries: built.extraGeometries,
         });
-        assignMeshesToCells(built.cells, built.mesh);
+        assignMeshesToWalls(built.cells, variantId, baseY, built.mesh);
       }
     }
   }
 
   function clearLastActionCell() {
     lastWallActionCellKey = '';
+    actionRepeatTimer = 0;
+    actionRepeatStarted = false;
+    primaryActionPrimed = false;
+    primaryActionPerformed = false;
   }
 
-  function removeUserWallAt(cellX, cellZ) {
-    const key = keyForCell(cellX, cellZ);
+  function emitStackFx(cellX, cellZ, y, color, count = 2) {
+    if (typeof burstAt !== 'function') return;
+    burstAt(cellX, Math.max(0.2, y), cellZ, color, count);
+  }
+
+  function removeUserWallAt(cellX, cellZ, baseY) {
+    const normalizedBaseY = normalizeWallBaseY(baseY);
+    let removedWall = null;
+
     for (let i = userWalls.length - 1; i >= 0; i -= 1) {
       const wall = userWalls[i];
-      if (wall.x === cellX && wall.z === cellZ) {
-        userWalls.splice(i, 1);
-        break;
-      }
+      if (wall.x !== cellX || wall.z !== cellZ) continue;
+      if (!areSameWallBase(wall.baseY || 0, normalizedBaseY)) continue;
+      removedWall = userWalls.splice(i, 1)[0];
+      break;
     }
-    userWallSet.delete(key);
+
+    if (!removedWall) return false;
+
+    updateUserWallSetForCell(cellX, cellZ);
     rebuildVisuals();
-    burstAt(cellX, 0.9, cellZ, 0x9fe8ff, 3);
+    emitStackFx(cellX, cellZ, normalizedBaseY + (getWallHeightValue(removedWall) * 0.5), 0x9fe8ff, 3);
     refreshHud();
+    return true;
   }
 
-  function toggleWallAtPlayer() {
+  function addUserWallAt(cellX, cellZ, variantId, baseY, assetHeight) {
+    const normalizedBaseY = normalizeWallBaseY(baseY);
+    const height = Number.isFinite(assetHeight) && assetHeight > 0 ? normalizeWallBaseY(assetHeight) : getWallHeightForVariant(variantId);
+
+    userWalls.push({
+      x: cellX,
+      z: cellZ,
+      baseY: normalizedBaseY,
+      height,
+      variant: variantId,
+      mesh: null,
+    });
+    updateUserWallSetForCell(cellX, cellZ);
+    rebuildVisuals();
+    emitStackFx(cellX, cellZ, normalizedBaseY + (height * 0.5), 0x75f7ff, 4);
+    refreshHud();
+    return true;
+  }
+
+  function getPlacementTarget(cellX, cellZ, variantId) {
+    const assetHeight = getWallHeightForVariant(variantId);
+    const supportTopY = getCellTopY(cellX, cellZ);
+    const baseY = normalizeWallBaseY(Math.max(0, supportTopY));
+    return {
+      assetHeight,
+      supportTopY,
+      baseY,
+      previewCenterY: normalizeWallBaseY(baseY + (assetHeight * 0.5)),
+    };
+  }
+
+  function getTopWallAtCell(cellX, cellZ) {
+    const walls = getCellWalls(cellX, cellZ);
+    if (!walls.length) return null;
+    return walls[walls.length - 1] || null;
+  }
+
+  function getPlayerPlacementCell() {
     const player = getPlayer();
-    if (!player) return;
+    if (!player) return null;
 
-    const placeX = Math.round(player.x);
-    const placeZ = Math.round(player.z);
-    const key = keyForCell(placeX, placeZ);
+    const cellX = Math.round(player.x);
+    const cellZ = Math.round(player.z);
+    if (Math.abs(cellX) >= BORDER_HALF || Math.abs(cellZ) >= BORDER_HALF) return null;
+    if (isBorderCell(cellX, cellZ)) return null;
 
-    if (Math.abs(placeX) >= BORDER_HALF || Math.abs(placeZ) >= BORDER_HALF) return;
-    if (isBorderCell(placeX, placeZ)) return;
-    if (lastWallActionCellKey === key) return;
-    lastWallActionCellKey = key;
+    return { cellX, cellZ };
+  }
 
-    if (userWallSet.has(key)) {
-      removeUserWallAt(placeX, placeZ);
+  function syncDestroySelectionCell(cellX, cellZ) {
+    const nextKey = `${cellX}|${cellZ}`;
+    if (destroySelectionCellKey === nextKey) return;
+    destroySelectionCellKey = nextKey;
+    destroySelectionOffsetFromTop = 0;
+  }
+
+  function getBuildSelectionCandidates(cellX, cellZ, variantId) {
+    const { supportTopY } = getPlacementTarget(cellX, cellZ, variantId);
+    const walls = getCellWalls(cellX, cellZ);
+    const candidates = [];
+
+    function pushCandidate(value) {
+      const normalizedValue = normalizeWallBaseY(Math.max(0, value));
+      if (candidates.some((candidate) => areSameWallBase(candidate, normalizedValue))) return;
+      candidates.push(normalizedValue);
+    }
+
+    pushCandidate(supportTopY);
+    pushCandidate(0);
+
+    for (let i = walls.length - 1; i >= 0; i -= 1) {
+      const wall = walls[i];
+      const wallBaseY = normalizeWallBaseY(wall.baseY || 0);
+      const wallTopY = normalizeWallBaseY(wallBaseY + getWallHeightValue(wall));
+      pushCandidate(wallBaseY);
+      pushCandidate(wallTopY);
+    }
+
+    candidates.sort((a, b) => b - a);
+    return candidates;
+  }
+
+  function getSelectedBuildTargetAtCell(cellX, cellZ, variantId) {
+    const candidates = getBuildSelectionCandidates(cellX, cellZ, variantId);
+    const maxOffset = Math.max(0, candidates.length - 1);
+    buildSelectionOffsetFromTop = Math.max(0, Math.min(buildSelectionOffsetFromTop, maxOffset));
+    const selectedBaseY = candidates[buildSelectionOffsetFromTop] ?? 0;
+    const assetHeight = getWallHeightForVariant(variantId);
+
+    return {
+      assetHeight,
+      baseY: normalizeWallBaseY(selectedBaseY),
+      previewCenterY: normalizeWallBaseY(selectedBaseY + (assetHeight * 0.5)),
+      supportTopY: normalizeWallBaseY(Math.max(0, getCellTopY(cellX, cellZ))),
+    };
+  }
+
+  function getSelectedDestroyWallAtCell(cellX, cellZ) {
+    syncDestroySelectionCell(cellX, cellZ);
+    const walls = getCellWalls(cellX, cellZ);
+    if (!walls.length) return null;
+    const maxOffset = Math.max(0, walls.length - 1);
+    destroySelectionOffsetFromTop = Math.max(0, Math.min(destroySelectionOffsetFromTop, maxOffset));
+    const selectedIndex = Math.max(0, walls.length - 1 - destroySelectionOffsetFromTop);
+    return walls[selectedIndex] || null;
+  }
+
+  function syncBuildSelectionToBaseY(cellX, cellZ, variantId, targetBaseY) {
+    const candidates = getBuildSelectionCandidates(cellX, cellZ, variantId);
+    if (!candidates.length) {
+      buildSelectionOffsetFromTop = 0;
       return;
     }
 
-    userWalls.push({ x: placeX, z: placeZ, variant: getCurrentVariant(), mesh: null });
-    userWallSet.add(key);
-    rebuildVisuals();
-    burstAt(placeX, 0.9, placeZ, 0x75f7ff, 4);
+    const normalizedTarget = normalizeWallBaseY(Math.max(0, targetBaseY || 0));
+    let bestIndex = 0;
+    let bestDistance = Infinity;
+
+    for (let i = 0; i < candidates.length; i += 1) {
+      const distance = Math.abs(candidates[i] - normalizedTarget);
+      if (distance < bestDistance) {
+        bestDistance = distance;
+        bestIndex = i;
+      }
+    }
+
+    buildSelectionOffsetFromTop = bestIndex;
+  }
+
+  function syncDestroySelectionToBaseY(cellX, cellZ, targetBaseY) {
+    syncDestroySelectionCell(cellX, cellZ);
+    const walls = getCellWalls(cellX, cellZ);
+    if (!walls.length) {
+      destroySelectionOffsetFromTop = 0;
+      return;
+    }
+
+    const normalizedTarget = normalizeWallBaseY(Math.max(0, targetBaseY || 0));
+    let bestIndex = walls.length - 1;
+    let bestDistance = Infinity;
+
+    for (let i = 0; i < walls.length; i += 1) {
+      const wallBaseY = normalizeWallBaseY(walls[i].baseY || 0);
+      const distance = Math.abs(wallBaseY - normalizedTarget);
+      if (distance < bestDistance) {
+        bestDistance = distance;
+        bestIndex = i;
+      }
+    }
+
+    destroySelectionOffsetFromTop = Math.max(0, walls.length - 1 - bestIndex);
+  }
+
+  function nudgeDestroySelection(direction) {
+    if (!destroyMode) return false;
+    const placementCell = getPlayerPlacementCell();
+    if (!placementCell) return false;
+    const { cellX, cellZ } = placementCell;
+    syncDestroySelectionCell(cellX, cellZ);
+    const walls = getCellWalls(cellX, cellZ);
+    if (!walls.length) return false;
+
+    const maxOffset = Math.max(0, walls.length - 1);
+    if (direction > 0) {
+      destroySelectionOffsetFromTop = Math.max(0, destroySelectionOffsetFromTop - 1);
+    } else if (direction < 0) {
+      destroySelectionOffsetFromTop = Math.min(maxOffset, destroySelectionOffsetFromTop + 1);
+    }
+
     refreshHud();
+    return true;
+  }
+
+  function nudgeBuildSelection(direction) {
+    if (destroyMode) return false;
+    const placementCell = getPlayerPlacementCell();
+    if (!placementCell) return false;
+    const { cellX, cellZ } = placementCell;
+    const variantId = getCurrentVariant();
+    const candidates = getBuildSelectionCandidates(cellX, cellZ, variantId);
+    if (!candidates.length) return false;
+
+    const maxOffset = Math.max(0, candidates.length - 1);
+    if (direction > 0) {
+      buildSelectionOffsetFromTop = Math.max(0, buildSelectionOffsetFromTop - 1);
+    } else if (direction < 0) {
+      buildSelectionOffsetFromTop = Math.min(maxOffset, buildSelectionOffsetFromTop + 1);
+    }
+
+    refreshHud();
+    return true;
+  }
+
+  function beginPrimaryActionHold() {
+    primaryActionPrimed = true;
+    primaryActionPerformed = false;
+    actionRepeatTimer = 0;
+    actionRepeatStarted = false;
+    lastWallActionCellKey = '';
+    primaryActionPerformed = performPrimaryWallActionAtPlayer() || primaryActionPerformed;
+  }
+
+  function endPrimaryActionHold({ allowTap = true } = {}) {
+    let performed = false;
+    if (primaryActionPrimed && !primaryActionPerformed && allowTap) {
+      performed = performPrimaryWallActionAtPlayer();
+    }
+    clearLastActionCell();
+    return performed;
+  }
+
+  function performPrimaryWallActionAtPlayer() {
+    const placementCell = getPlayerPlacementCell();
+    if (!placementCell) return false;
+
+    const { cellX: placeX, cellZ: placeZ } = placementCell;
+
+    if (destroyMode) {
+      const selectedWall = getSelectedDestroyWallAtCell(placeX, placeZ);
+      if (!selectedWall) return false;
+      const destroyBaseY = normalizeWallBaseY(selectedWall.baseY || 0);
+      const destroyActionKey = `destroy@@${makeWallActionKey(placeX, placeZ, destroyBaseY)}`;
+      if (lastWallActionCellKey === destroyActionKey) return false;
+      const removed = removeUserWallAt(placeX, placeZ, destroyBaseY);
+      if (removed) lastWallActionCellKey = destroyActionKey;
+      return removed;
+    }
+
+    const variantId = getCurrentVariant();
+    const { baseY, assetHeight } = getSelectedBuildTargetAtCell(placeX, placeZ, variantId);
+    const buildActionKey = `build@@${makeWallActionKey(placeX, placeZ, baseY)}`;
+    if (lastWallActionCellKey === buildActionKey) return false;
+
+    const existingWall = findWallAtBaseY(placeX, placeZ, baseY);
+    let changed = false;
+
+    if (existingWall) {
+      const removed = removeUserWallAt(placeX, placeZ, baseY);
+      if (!removed) return false;
+      changed = true;
+    }
+
+    const added = addUserWallAt(placeX, placeZ, variantId, baseY, assetHeight);
+    if (added || changed) lastWallActionCellKey = buildActionKey;
+    return added || changed;
+  }
+
+  function updatePrimaryActionHold(delta, { primaryHeld = false, bypassInitialDelay = false } = {}) {
+    if (!primaryActionPrimed || !primaryHeld) return;
+
+    actionRepeatTimer += delta;
+
+    if (!actionRepeatStarted) {
+      const initialDelay = bypassInitialDelay ? WALL_ACTION_REPEAT_DELAY : WALL_ACTION_REPEAT_INITIAL_DELAY;
+      if (actionRepeatTimer < initialDelay) return;
+      actionRepeatTimer -= initialDelay;
+      actionRepeatStarted = true;
+      primaryActionPerformed = performPrimaryWallActionAtPlayer() || primaryActionPerformed;
+      return;
+    }
+
+    while (actionRepeatTimer >= WALL_ACTION_REPEAT_DELAY) {
+      actionRepeatTimer -= WALL_ACTION_REPEAT_DELAY;
+      primaryActionPerformed = performPrimaryWallActionAtPlayer() || primaryActionPerformed;
+    }
+  }
+
+  function toggleDestroyMode() {
+    const placementCell = getPlayerPlacementCell();
+    const currentVariant = getCurrentVariant();
+    let preservedBaseY = null;
+
+    if (placementCell) {
+      if (destroyMode) {
+        const selectedWall = getSelectedDestroyWallAtCell(placementCell.cellX, placementCell.cellZ);
+        preservedBaseY = selectedWall ? normalizeWallBaseY(selectedWall.baseY || 0) : null;
+      } else {
+        preservedBaseY = getSelectedBuildTargetAtCell(
+          placementCell.cellX,
+          placementCell.cellZ,
+          currentVariant,
+        ).baseY;
+      }
+    }
+
+    destroyMode = !destroyMode;
+
+    if (placementCell && Number.isFinite(preservedBaseY)) {
+      if (destroyMode) {
+        syncDestroySelectionToBaseY(placementCell.cellX, placementCell.cellZ, preservedBaseY);
+      } else {
+        syncBuildSelectionToBaseY(placementCell.cellX, placementCell.cellZ, currentVariant, preservedBaseY);
+      }
+    } else if (destroyMode) {
+      destroySelectionOffsetFromTop = 0;
+      destroySelectionCellKey = '';
+    }
+
+    clearLastActionCell();
+    refreshHud();
+    return destroyMode;
+  }
+
+  function isDestroyModeActive() {
+    return destroyMode;
+  }
+
+  function getStackState() {
+    const currentVariant = getCurrentVariant();
+    const stepHeight = getWallHeightForVariant(currentVariant);
+    const placementCell = getPlayerPlacementCell();
+    const placementTarget = placementCell ? getSelectedBuildTargetAtCell(placementCell.cellX, placementCell.cellZ, currentVariant) : null;
+    let previewBaseY = placementTarget ? placementTarget.baseY : 0;
+    let previewCenterY = placementTarget ? placementTarget.previewCenterY : (stepHeight * 0.5);
+    let previewTopY = normalizeWallBaseY(previewBaseY + stepHeight);
+    let displayLevel = stepHeight > WALL_BASE_EPSILON
+      ? Math.max(0, Math.round(previewBaseY / stepHeight))
+      : 0;
+    let previewCellX = placementCell ? placementCell.cellX : 0;
+    let previewCellZ = placementCell ? placementCell.cellZ : 0;
+
+    if (destroyMode && placementCell) {
+      const selectedWall = getSelectedDestroyWallAtCell(placementCell.cellX, placementCell.cellZ);
+      if (selectedWall) {
+        const selectedBaseY = normalizeWallBaseY(selectedWall.baseY || 0);
+        const selectedHeight = getWallHeightValue(selectedWall);
+        previewBaseY = selectedBaseY;
+        previewCenterY = normalizeWallBaseY(selectedBaseY + (selectedHeight * 0.5));
+        previewTopY = normalizeWallBaseY(selectedBaseY + selectedHeight);
+        displayLevel = selectedHeight > WALL_BASE_EPSILON
+          ? Math.max(0, Math.round(selectedBaseY / selectedHeight))
+          : displayLevel;
+      }
+    }
+
+    return {
+      level: displayLevel,
+      displayLevel,
+      stepHeight,
+      destroyMode,
+      previewBaseY,
+      previewCenterY,
+      previewTopY,
+      previewCellX,
+      previewCellZ,
+      supportTopY: placementTarget ? placementTarget.supportTopY : 0,
+      buildSelectionOffsetFromTop,
+    };
   }
 
   function dispose() {
     clearRenderedEntries();
     materialCache.forEach((material) => material.dispose());
     materialCache.clear();
+    variantHeightCache.clear();
   }
 
-  return { toggleWallAtPlayer, clearLastActionCell, rebuildVisuals, dispose };
+  return {
+    performPrimaryWallActionAtPlayer,
+    beginPrimaryActionHold,
+    endPrimaryActionHold,
+    updatePrimaryActionHold,
+    clearLastActionCell,
+    toggleDestroyMode,
+    isDestroyModeActive,
+    nudgeDestroySelection,
+    nudgeBuildSelection,
+    getStackState,
+    rebuildVisuals,
+    dispose,
+  };
 }


### PR DESCRIPTION
## Résumé

Cette branche ajoute un système d’empilement vertical basé sur la hauteur réelle de l’asset courant dans le mode `Wall`.

## Ajouts principaux

- empilement vertical fonctionnel dans une même colonne
- calcul du placement à partir de la hauteur réelle des assets
- construction et destruction à différents niveaux d’une pile
- conservation du niveau ciblé lors du passage build / destroy
- amélioration du feedback visuel avec le cercle de ciblage
- ajustements UX sur le rythme de pose, le maintien des touches et le ciblage sur grille

## Résultat

Le joueur peut maintenant :
- empiler des briques sur l’axe `Y`
- viser un niveau précis dans une pile
- remplacer ou supprimer une brique intermédiaire
- construire et détruire de façon plus lisible et plus fluide