### PR TITLE
fix - preserve edit height after build and destroy actions - Snap-ren…

### DIFF
--- a/src/assets/customAssets.js
+++ b/src/assets/customAssets.js
@@ -11,6 +11,7 @@ const HEX_ROW_OFFSET = 0.5;
 const HEX_IMPORT_SCALE_X = 1.25;
 const HEX_IMPORT_SCALE_Y = 1.25;
 const HEX_IMPORT_SCALE_Z = 1.25;
+//const CUSTOM_IMPORT_SCALE_Y = 3.0;
 
 function roundToHalfStep(value) {
   return Math.round((Number(value) || 0) * 2) / 2;
@@ -915,7 +916,7 @@ export function createCustomAssetRegistry({ THREE, storageKey = STORAGE_KEY } = 
     const isHex = normalizeGridMode(record.gridMode) === GRID_MODE_HEX;
     const template = createNormalizedTemplate(THREE, geometry, material, {
       scaleX: isHex ? HEX_IMPORT_SCALE_X : 1,
-      scaleY: isHex ? HEX_IMPORT_SCALE_Y : 1,
+      scaleY: isHex ? HEX_IMPORT_SCALE_Y : 1, //CUSTOM_IMPORT_SCALE_Y,
       scaleZ: isHex ? HEX_IMPORT_SCALE_Z : 1,
     });
     recordTemplates.set(record.id, template);

--- a/src/entities/player.js
+++ b/src/entities/player.js
@@ -6,7 +6,7 @@ import { INNER_LIMIT as DEFAULT_INNER_LIMIT } from '../config.js';
 import { getPlayerModeDef } from './playerModes.js';
 
 const WALL_GRID_SNAP_EPSILON = 0.001;
-const WALL_GRID_SNAP_LERP_SPEED = 12;
+const WALL_GRID_SNAP_LERP_SPEED = 22;
 
 function smoothToward(current, target, delta, speed) {
   if (!Number.isFinite(current) || !Number.isFinite(target)) return target;
@@ -449,7 +449,7 @@ export function createPlayerSystem({
     }
 
     const sprintHeld = actions ? actions.isSprintHeld() : !!(keys && keys.shift);
-    const speed = player.speed * getSpeedMultiplier() * (sprintHeld ? 1.22 : 1.0);
+    const speed = player.speed * getSpeedMultiplier() * (sprintHeld ? 1.0 : 1.0);
 
     const stepX = moveX * speed * delta;
     const stepZ = moveZ * speed * delta;

--- a/src/main.js
+++ b/src/main.js
@@ -396,8 +396,16 @@ const THREE = window.THREE;
   }
 
   function refreshHud() {
+    const wallModeActive = !inventoryOpen
+      && !!modeSystem
+      && typeof modeSystem.getCurrentMode === 'function'
+      && modeSystem.getCurrentMode() === 'wall';
+    const editSelectionHold = wallModeActive
+      && actions
+      && typeof actions.isSprintHeld === 'function'
+      && actions.isSprintHeld();
     const stackState = wallsSystem && typeof wallsSystem.getStackState === 'function'
-      ? wallsSystem.getStackState()
+      ? wallsSystem.getStackState({ preserveSelection: editSelectionHold })
       : { level: -1, displayLevel: 0, stepHeight: 0, destroyMode: false };
 
     if (playerSystem && typeof playerSystem.setBuildIndicator === 'function') {
@@ -406,7 +414,7 @@ const THREE = window.THREE;
         ? customAssetRegistry.resolveWallSelection(selectedWallVariant)
         : selectedWallVariant;
       playerSystem.setBuildIndicator({
-        active: !inventoryOpen && !!modeSystem && typeof modeSystem.getCurrentMode === 'function' && modeSystem.getCurrentMode() === 'wall',
+        active: wallModeActive,
         level: stackState.level,
         destroyMode: !!stackState.destroyMode,
         previewBaseY: stackState.previewBaseY,
@@ -634,8 +642,12 @@ const THREE = window.THREE;
       const primaryHeld = actions.isPrimaryActionHeld();
       const primaryReleased = actions.consumePrimaryActionRelease();
 
+      const shiftHeld = typeof actions.isSprintHeld === 'function'
+        ? actions.isSprintHeld()
+        : false;
+
       if (primaryPressed && typeof wallsSystem.beginPrimaryActionHold === 'function') {
-        wallsSystem.beginPrimaryActionHold();
+        wallsSystem.beginPrimaryActionHold({ preserveSelection: shiftHeld });
       }
 
       if (typeof wallsSystem.updatePrimaryActionHold === 'function') {
@@ -644,9 +656,6 @@ const THREE = window.THREE;
           : { x: 0, z: 0 };
         const directionalHeld = !!movementIntent?.x || !!movementIntent?.z;
         const movementVector = projectMovementIntentToWorld(movementIntent);
-        const shiftHeld = typeof actions.isSprintHeld === 'function'
-          ? actions.isSprintHeld()
-          : false;
 
         wallsSystem.updatePrimaryActionHold(delta, {
           primaryHeld,
@@ -659,7 +668,7 @@ const THREE = window.THREE;
 
       if (primaryReleased) {
         if (typeof wallsSystem.endPrimaryActionHold === 'function') {
-          wallsSystem.endPrimaryActionHold({ allowTap: true });
+          wallsSystem.endPrimaryActionHold({ allowTap: true, preserveSelection: shiftHeld });
         } else if (typeof wallsSystem.clearLastActionCell === 'function') {
           wallsSystem.clearLastActionCell();
         }

--- a/src/world/walls.js
+++ b/src/world/walls.js
@@ -480,7 +480,7 @@ function addCylinderBetween(THREE, group, geometry, material, start, end) {
 function buildNodeGridMeshes({ THREE, scene, cells, style, material }) {
   const group = new THREE.Group();
   const occupied = new Set(cells.map((cell) => keyForVariantCell(cell.x, cell.z)));
-  const nodeGeo = new THREE.CylinderGeometry(0.11, 0.14, 2, 10);
+  const nodeGeo = new THREE.CylinderGeometry(0.11, 0.14, 1, 10);
   const linkGeo = new THREE.CylinderGeometry(0.038, 0.038, 1, 8);
   const capGeo = new THREE.SphereGeometry(0.11, 10, 10);
 
@@ -493,7 +493,7 @@ function buildNodeGridMeshes({ THREE, scene, cells, style, material }) {
     group.add(node);
 
     const cap = new THREE.Mesh(capGeo, material);
-    cap.position.set(x, style.surfaceY + 1.35, z);
+    cap.position.set(x, style.surfaceY + 0.7, z);
     cap.castShadow = true;
     cap.receiveShadow = true;
     group.add(cap);
@@ -504,8 +504,8 @@ function buildNodeGridMeshes({ THREE, scene, cells, style, material }) {
         group,
         linkGeo,
         material,
-        new THREE.Vector3(x, style.surfaceY + 0.8, z),
-        new THREE.Vector3(x + 1, style.surfaceY + 0.8, z),
+        new THREE.Vector3(x, style.surfaceY + 0.5, z),
+        new THREE.Vector3(x + 1, style.surfaceY + 0.5, z),
       );
     }
     if (occupied.has(keyForVariantCell(x, z + 1))) {
@@ -514,8 +514,8 @@ function buildNodeGridMeshes({ THREE, scene, cells, style, material }) {
         group,
         linkGeo,
         material,
-        new THREE.Vector3(x, style.surfaceY + 0.8, z),
-        new THREE.Vector3(x, style.surfaceY + 0.8, z + 1),
+        new THREE.Vector3(x, style.surfaceY + 0.5, z),
+        new THREE.Vector3(x, style.surfaceY + 0.5, z + 1),
       );
     }
   }
@@ -1299,20 +1299,36 @@ export function createWallsSystem({
     return { cellX, cellZ };
   }
 
-  function syncBuildSelectionCell(cellX, cellZ, variantId) {
+  function syncBuildSelectionCell(cellX, cellZ, variantId, { preserveSelection = false } = {}) {
     const nextKey = `${cellX}|${cellZ}|${variantId}`;
     if (buildSelectionCellKey === nextKey) return;
     buildSelectionCellKey = nextKey;
+
+    if (preserveSelection) {
+      verticalTargetBaseY = normalizeWallBaseY(Math.max(0, verticalTargetBaseY));
+      return;
+    }
+
     buildSelectionManualActive = false;
     const placementTarget = getPlacementTarget(cellX, cellZ, variantId);
     verticalTargetBaseY = normalizeWallBaseY(Math.max(0, placementTarget.supportTopY || 0));
   }
 
-  function syncDestroySelectionCell(cellX, cellZ) {
+  function syncDestroySelectionCell(cellX, cellZ, { preserveSelection = false } = {}) {
     const nextKey = `${cellX}|${cellZ}`;
     if (destroySelectionCellKey === nextKey) return;
     destroySelectionCellKey = nextKey;
     destroySelectionOffsetFromTop = 0;
+
+    if (preserveSelection) {
+      verticalTargetBaseY = normalizeWallBaseY(Math.max(0, verticalTargetBaseY));
+      return;
+    }
+
+    const topWall = getTopWallAtCell(cellX, cellZ);
+    if (topWall) {
+      verticalTargetBaseY = normalizeWallBaseY(Math.max(0, topWall.baseY || 0));
+    }
   }
 
   function getBuildSelectionCandidates(cellX, cellZ, variantId) {
@@ -1341,8 +1357,8 @@ export function createWallsSystem({
     return candidates;
   }
 
-  function getSelectedBuildTargetAtCell(cellX, cellZ, variantId) {
-    syncBuildSelectionCell(cellX, cellZ, variantId);
+  function getSelectedBuildTargetAtCell(cellX, cellZ, variantId, { preserveSelection = false } = {}) {
+    syncBuildSelectionCell(cellX, cellZ, variantId, { preserveSelection });
     const placementTarget = getPlacementTarget(cellX, cellZ, variantId);
     const candidates = getBuildSelectionCandidates(cellX, cellZ, variantId);
     const desiredBaseY = normalizeWallBaseY(Math.max(0, verticalTargetBaseY));
@@ -1350,7 +1366,7 @@ export function createWallsSystem({
     let selectedBaseY = placementTarget.supportTopY;
     let selectedIndex = candidates.indexOf(selectedBaseY);
 
-    if (buildSelectionManualActive) {
+    if (buildSelectionManualActive || preserveSelection) {
       if (desiredBaseY > (placementTarget.supportTopY + WALL_BASE_EPSILON)) {
         selectedBaseY = desiredBaseY;
         selectedIndex = 0;
@@ -1379,8 +1395,8 @@ export function createWallsSystem({
     };
   }
 
-  function getSelectedDestroyWallAtCell(cellX, cellZ) {
-    syncDestroySelectionCell(cellX, cellZ);
+  function getSelectedDestroyWallAtCell(cellX, cellZ, { preserveSelection = false } = {}) {
+    syncDestroySelectionCell(cellX, cellZ, { preserveSelection });
     const walls = getCellWalls(cellX, cellZ);
     if (!walls.length) return null;
 
@@ -1517,41 +1533,47 @@ export function createWallsSystem({
     return selectedAssetRollZ;
   }
 
-  function beginPrimaryActionHold() {
+  function beginPrimaryActionHold({ preserveSelection = false } = {}) {
     primaryActionPrimed = true;
     primaryActionPerformed = false;
     actionRepeatTimer = 0;
     actionRepeatStarted = false;
     lastWallActionCellKey = '';
     clearDirectionalTraversalState();
-    primaryActionPerformed = performPrimaryWallActionAtPlayer() || primaryActionPerformed;
+    primaryActionPerformed = performPrimaryWallActionAtPlayer({ preserveSelection }) || primaryActionPerformed;
   }
 
-  function endPrimaryActionHold({ allowTap = true } = {}) {
+  function endPrimaryActionHold({ allowTap = true, preserveSelection = false } = {}) {
     let performed = false;
     if (primaryActionPrimed && !primaryActionPerformed && allowTap) {
-      performed = performPrimaryWallActionAtPlayer();
+      performed = performPrimaryWallActionAtPlayer({ preserveSelection });
     }
     clearLastActionCell();
     return performed;
   }
 
-  function performPrimaryWallActionAtCell(placeX, placeZ) {
+  function performPrimaryWallActionAtCell(placeX, placeZ, { preserveSelection = false } = {}) {
     if (!isValidPlacementCell(placeX, placeZ)) return false;
 
     if (destroyMode) {
-      const selectedWall = getSelectedDestroyWallAtCell(placeX, placeZ);
+      const selectedWall = getSelectedDestroyWallAtCell(placeX, placeZ, { preserveSelection });
       if (!selectedWall) return false;
       const destroyBaseY = normalizeWallBaseY(selectedWall.baseY || 0);
       const destroyActionKey = `destroy@@${makeWallActionKey(placeX, placeZ, destroyBaseY)}`;
       if (lastWallActionCellKey === destroyActionKey) return false;
       const removed = removeUserWallAt(placeX, placeZ, destroyBaseY);
-      if (removed) lastWallActionCellKey = destroyActionKey;
+      if (removed) {
+        if (preserveSelection) {
+          syncDestroySelectionToBaseY(placeX, placeZ, destroyBaseY);
+          refreshHud();
+        }
+        lastWallActionCellKey = destroyActionKey;
+      }
       return removed;
     }
 
     const variantId = getCurrentVariant();
-    const { baseY, assetHeight } = getSelectedBuildTargetAtCell(placeX, placeZ, variantId);
+    const { baseY, assetHeight } = getSelectedBuildTargetAtCell(placeX, placeZ, variantId, { preserveSelection });
     const rotationY = selectedAssetRotationY;
     const tiltX = selectedAssetTiltX;
     const rollZ = selectedAssetRollZ;
@@ -1569,18 +1591,21 @@ export function createWallsSystem({
 
     const added = addUserWallAt(placeX, placeZ, variantId, baseY, assetHeight, rotationY, tiltX, rollZ);
     if (added || changed) {
-      const nextTopY = normalizeWallBaseY(baseY + assetHeight);
-      syncBuildSelectionToBaseY(placeX, placeZ, variantId, nextTopY, false);
+      const nextBaseY = preserveSelection
+        ? baseY
+        : normalizeWallBaseY(baseY + assetHeight);
+      syncBuildSelectionToBaseY(placeX, placeZ, variantId, nextBaseY, preserveSelection);
+      if (preserveSelection) refreshHud();
       lastWallActionCellKey = buildActionKey;
     }
     return added || changed;
   }
 
-  function performPrimaryWallActionAtPlayer() {
+  function performPrimaryWallActionAtPlayer(options = {}) {
     const placementCell = getPlayerPlacementCell();
     if (!placementCell) return false;
 
-    return performPrimaryWallActionAtCell(placementCell.cellX, placementCell.cellZ);
+    return performPrimaryWallActionAtCell(placementCell.cellX, placementCell.cellZ, options);
   }
 
   function updatePrimaryActionHold(delta, {
@@ -1621,7 +1646,7 @@ export function createWallsSystem({
           + (directionalTraversalState.stepX * directionalTraversalState.progress);
         const nextCellZ = directionalTraversalState.anchorCellZ
           + (directionalTraversalState.stepZ * directionalTraversalState.progress);
-        primaryActionPerformed = performPrimaryWallActionAtCell(nextCellX, nextCellZ) || primaryActionPerformed;
+        primaryActionPerformed = performPrimaryWallActionAtCell(nextCellX, nextCellZ, { preserveSelection: shiftHeld }) || primaryActionPerformed;
       }
       return;
     }
@@ -1639,13 +1664,13 @@ export function createWallsSystem({
       if (actionRepeatTimer < initialDelay) return;
       actionRepeatTimer -= initialDelay;
       actionRepeatStarted = true;
-      primaryActionPerformed = performPrimaryWallActionAtPlayer() || primaryActionPerformed;
+      primaryActionPerformed = performPrimaryWallActionAtPlayer({ preserveSelection: shiftHeld }) || primaryActionPerformed;
       return;
     }
 
     while (actionRepeatTimer >= WALL_ACTION_REPEAT_DELAY) {
       actionRepeatTimer -= WALL_ACTION_REPEAT_DELAY;
-      primaryActionPerformed = performPrimaryWallActionAtPlayer() || primaryActionPerformed;
+      primaryActionPerformed = performPrimaryWallActionAtPlayer({ preserveSelection: shiftHeld }) || primaryActionPerformed;
     }
   }
 
@@ -1656,8 +1681,7 @@ export function createWallsSystem({
 
     if (placementCell) {
       if (destroyMode) {
-        const selectedWall = getSelectedDestroyWallAtCell(placementCell.cellX, placementCell.cellZ);
-        preservedBaseY = selectedWall ? normalizeWallBaseY(selectedWall.baseY || 0) : null;
+        preservedBaseY = normalizeWallBaseY(Math.max(0, verticalTargetBaseY));
       } else {
         preservedBaseY = getSelectedBuildTargetAtCell(
           placementCell.cellX,
@@ -1703,11 +1727,13 @@ export function createWallsSystem({
     };
   }
 
-  function getStackState() {
+  function getStackState({ preserveSelection = false } = {}) {
     const currentVariant = getCurrentVariant();
     const stepHeight = getWallHeightForVariant(currentVariant);
     const placementCell = getPlayerPlacementCell();
-    const placementTarget = placementCell ? getSelectedBuildTargetAtCell(placementCell.cellX, placementCell.cellZ, currentVariant) : null;
+    const placementTarget = placementCell
+      ? getSelectedBuildTargetAtCell(placementCell.cellX, placementCell.cellZ, currentVariant, { preserveSelection })
+      : null;
     let previewBaseY = placementTarget ? placementTarget.baseY : 0;
     let previewCenterY = placementTarget ? placementTarget.previewCenterY : (stepHeight * 0.5);
     let previewTopY = normalizeWallBaseY(previewBaseY + stepHeight);
@@ -1721,7 +1747,7 @@ export function createWallsSystem({
     let previewCellZ = placementCell ? placementCell.cellZ : 0;
 
     if (destroyMode && placementCell) {
-      const selectedWall = getSelectedDestroyWallAtCell(placementCell.cellX, placementCell.cellZ);
+      const selectedWall = getSelectedDestroyWallAtCell(placementCell.cellX, placementCell.cellZ, { preserveSelection });
       if (selectedWall) {
         const selectedBaseY = normalizeWallBaseY(selectedWall.baseY || 0);
         const selectedHeight = getWallHeightValue(selectedWall);


### PR DESCRIPTION
…forced - Vitesse mode shift

-Snap renforcé
// src/entities/player.js
const WALL_GRID_SNAP_EPSILON = 0.001;
const WALL_GRID_SNAP_LERP_SPEED = 12; 
//Corrigé pour =22

-Vitesse en mode build + shift supprimé
// src/entities/player.js
const sprintHeld = actions ? actions.isSprintHeld() : !!(keys && keys.shift); const speed = player.speed * getSpeedMultiplier() * (sprintHeld ? 1.22 : 1.0);
//Corrigé pour (sprintHeld ? 1.0 : 1.0);

-Taille de custom asset Y : customAssets.js
ligne 919 - scaleY: isHex ? HEX_IMPORT_SCALE_Y : 1, //CUSTOM_IMPORT_SCALE_Y,